### PR TITLE
Fix homepage links

### DIFF
--- a/couchbase-orm.gemspec
+++ b/couchbase-orm.gemspec
@@ -6,6 +6,12 @@ Gem::Specification.new do |gem|
   gem.license = 'Apache-2.0'
   gem.authors = ['Stephen von Takach', 'Gauthier Monserand', 'Pierre Merlin', 'Julien Burnet-Fauche']
   gem.homepage = 'https://github.com/Couchbase-Ecosystem/couchbase-ruby-orm'
+  gem.metadata = {
+    "source_code_uri" => "https://github.com/Couchbase-Ecosystem/couchbase-ruby-orm",
+    "bug_tracker_uri" => "https://github.com/Couchbase-Ecosystem/couchbase-ruby-orm/issues",
+    "documentation_uri" => "https://couchbase-ruby-orm.com/"
+    "homepage_uri" => "https://github.com/Couchbase-Ecosystem/couchbase-ruby-orm"
+  }
   gem.summary = 'Couchbase ORM for Rails'
   gem.description = 'A Couchbase ORM for Rails'
 

--- a/couchbase-orm.gemspec
+++ b/couchbase-orm.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.metadata = {
     "source_code_uri" => "https://github.com/Couchbase-Ecosystem/couchbase-ruby-orm",
     "bug_tracker_uri" => "https://github.com/Couchbase-Ecosystem/couchbase-ruby-orm/issues",
-    "documentation_uri" => "https://couchbase-ruby-orm.com/"
+    "documentation_uri" => "https://couchbase-ruby-orm.com/",
     "homepage_uri" => "https://github.com/Couchbase-Ecosystem/couchbase-ruby-orm"
   }
   gem.summary = 'Couchbase ORM for Rails'

--- a/lib/couchbase-orm/version.rb
+++ b/lib/couchbase-orm/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true, encoding: ASCII-8BIT
 
 module CouchbaseOrm
-  VERSION = '2.0.2'
+  VERSION = '2.0.3'
 end


### PR DESCRIPTION
Links in Rubytoolbox and Rubygems.org were still pointing to cotag repo.
Explication can be found here : https://github.com/rubygems/rubygems.org/issues/2375#issuecomment-636506283