### PR TITLE
👷 Add Ruby version 3.4 to CI grid

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,12 @@ jobs:
           - ruby: '3.2'
             active-model: '7.1.0'
             couchbase: '6.6.5'
+          - ruby: '3.0'
+            gemfile: '7.0.0'
+            couchbase: '7.1.0'
+          - ruby: '2.7'
+            gemfile: '7.0.0'
+            couchbase: '7.1.0'
       fail-fast: false
     runs-on: ubuntu-20.04
     name: ${{ matrix.ruby }} rails-${{ matrix.active-model }}  couchbase-${{ matrix.couchbase }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,9 +23,6 @@ jobs:
           - ruby: '3.2'
             active-model: '7.1.0'
             couchbase: '6.6.5'
-          - ruby: '3.1'
-            active-model: '7.1.0'
-            couchbase: '7.1.0'
       fail-fast: false
     runs-on: ubuntu-20.04
     name: ${{ matrix.ruby }} rails-${{ matrix.active-model }}  couchbase-${{ matrix.couchbase }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,9 +23,6 @@ jobs:
           - ruby: '3.0'
             gemfile: '7.0.0'
             couchbase: '7.1.0'
-          - ruby: '2.7'
-            gemfile: '7.0.0'
-            couchbase: '7.1.0'
       fail-fast: false
     runs-on: ubuntu-20.04
     name: ${{ matrix.ruby }} rails-${{ matrix.gemfile }}  couchbase-${{ matrix.couchbase }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ jobs:
     strategy:
       matrix:
         include:
+          - ruby: '3.4'
+            active-model: '8.0.2'
+            couchbase: '7.2.3'
           - ruby: '3.3'
             active-model: '8.0.0'
             couchbase: '7.2.3'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,10 @@ jobs:
           - ruby: '3.2'
             gemfile: '7.1.0'
             couchbase: '7.1.1'
-          - ruby: '3.0'
+          - ruby: '3.1'
             gemfile: '7.0.0'
             couchbase: '6.6.5'
-          - ruby: '3.0'
+          - ruby: '3.1'
             gemfile: '7.0.0'
             couchbase: '7.1.0'
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,20 +12,23 @@ jobs:
       matrix:
         include:
           - ruby: '3.3'
-            gemfile: '7.1.0'
+            active-model: '8.0.0'
+            couchbase: '7.2.3'
+          - ruby: '3.3'
+            active-model: '7.2'
             couchbase: '7.2.3'
           - ruby: '3.2'
-            gemfile: '7.1.0'
+            active-model: '7.2.0'
             couchbase: '7.1.1'
-          - ruby: '3.1'
-            gemfile: '7.0.0'
+          - ruby: '3.2'
+            active-model: '7.1.0'
             couchbase: '6.6.5'
           - ruby: '3.1'
-            gemfile: '7.0.0'
+            active-model: '7.1.0'
             couchbase: '7.1.0'
       fail-fast: false
     runs-on: ubuntu-20.04
-    name: ${{ matrix.ruby }} rails-${{ matrix.gemfile }}  couchbase-${{ matrix.couchbase }}
+    name: ${{ matrix.ruby }} rails-${{ matrix.active-model }}  couchbase-${{ matrix.couchbase }}
     steps:
     - uses: actions/checkout@v3
     - run: sudo apt-get update && sudo apt-get install libevent-dev libev-dev python-httplib2
@@ -36,7 +39,7 @@ jobs:
     - run: sudo ./ci/run_couchbase.sh $COUCHBASE_VERSION $COUCHBASE_BUCKET $COUCHBASE_USER $COUCHBASE_PASSWORD
     - run: bundle exec rspec
     env:
-      ACTIVE_MODEL_VERSION: ${{ matrix.gemfile }}
+      ACTIVE_MODEL_VERSION: ${{ matrix.active-model }}
       BUNDLE_JOBS: 4
       BUNDLE_PATH: vendor/bundle
       COUCHBASE_BUCKET: default

--- a/couchbase-orm.gemspec
+++ b/couchbase-orm.gemspec
@@ -15,10 +15,10 @@ Gem::Specification.new do |gem|
   gem.summary = 'Couchbase ORM for Rails'
   gem.description = 'A Couchbase ORM for Rails'
 
-  gem.required_ruby_version = '>= 3.2.0'
+  gem.required_ruby_version = '>= 2.7.0'
   gem.require_paths = ['lib']
 
-  gem.add_runtime_dependency 'activemodel', ENV['ACTIVE_MODEL_VERSION'] || '>= 7.1'
+  gem.add_runtime_dependency 'activemodel', ENV['ACTIVE_MODEL_VERSION'] || '>= 5.2'
 
   gem.add_runtime_dependency     'couchbase',    '>= 3.4.2'
   gem.add_runtime_dependency     'radix',        '~> 2.2' # converting numbers to and from any base

--- a/couchbase-orm.gemspec
+++ b/couchbase-orm.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.summary = 'Couchbase ORM for Rails'
   gem.description = 'A Couchbase ORM for Rails'
 
-  gem.required_ruby_version = '>= 3.1.0'
+  gem.required_ruby_version = '>= 3.2.0'
   gem.require_paths = ['lib']
 
   gem.add_runtime_dependency 'activemodel', ENV['ACTIVE_MODEL_VERSION'] || '>= 7.1'

--- a/couchbase-orm.gemspec
+++ b/couchbase-orm.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 3.1.0'
   gem.require_paths = ['lib']
 
-  gem.add_runtime_dependency 'activemodel', ENV['ACTIVE_MODEL_VERSION'] || '>= 5.2'
+  gem.add_runtime_dependency 'activemodel', ENV['ACTIVE_MODEL_VERSION'] || '>= 7.1'
 
   gem.add_runtime_dependency     'couchbase',    '>= 3.4.2'
   gem.add_runtime_dependency     'radix',        '~> 2.2' # converting numbers to and from any base

--- a/couchbase-orm.gemspec
+++ b/couchbase-orm.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.summary = 'Couchbase ORM for Rails'
   gem.description = 'A Couchbase ORM for Rails'
 
-  gem.required_ruby_version = '>= 2.7.0'
+  gem.required_ruby_version = '>= 3.1.0'
   gem.require_paths = ['lib']
 
   gem.add_runtime_dependency 'activemodel', ENV['ACTIVE_MODEL_VERSION'] || '>= 5.2'


### PR DESCRIPTION
# Why ?

Ruby 3.4 has been released and we want to cover up to date setups.

# HOW ?

- **Add Ruby 3.4 in test grid**
