### PR TITLE
Add adhoc option to control prepared-statement caching

### DIFF
--- a/lib/couchbase-orm/n1ql.rb
+++ b/lib/couchbase-orm/n1ql.rb
@@ -23,7 +23,8 @@ module CouchbaseOrm
         def self.config(new_config = nil)
             Thread.current['__couchbaseorm_n1ql_config__'] = new_config if new_config
             Thread.current['__couchbaseorm_n1ql_config__'] || {
-                scan_consistency: DEFAULT_SCAN_CONSISTENCY
+                scan_consistency: DEFAULT_SCAN_CONSISTENCY,
+                adhoc: true
             }
         end
 
@@ -130,10 +131,11 @@ module CouchbaseOrm
                     limit = build_limit(limit)
                     n1ql_query = "select raw meta().id from `#{bucket_name}` where #{where} order by #{order} #{limit}"
 
-                    query_options = options.merge(positional_parameters: params)
+                    adhoc = options.delete(:adhoc) { CouchbaseOrm::N1ql.config[:adhoc] }
+                    query_options = options.merge(positional_parameters: params, adhoc: adhoc)
                     result = cluster.query(n1ql_query, Couchbase::Options::Query.new(**query_options))
                     CouchbaseOrm.logger.debug {
-                        "N1QL query: #{n1ql_query} params: #{params.inspect} return #{result.rows.to_a.length} rows with scan_consistency: #{options[:scan_consistency]}"
+                        "N1QL query: #{n1ql_query} params: #{params.inspect} return #{result.rows.to_a.length} rows with scan_consistency: #{options[:scan_consistency]} adhoc: #{adhoc}"
                     }
                     N1qlProxy.new(result)
                 end

--- a/lib/couchbase-orm/relation.rb
+++ b/lib/couchbase-orm/relation.rb
@@ -236,6 +236,8 @@ module CouchbaseOrm
             def build_query_options(positional_parameters: [])
                 opts = { scan_consistency: CouchbaseOrm::N1ql.config[:scan_consistency] }
                 opts[:positional_parameters] = positional_parameters unless positional_parameters.empty?
+                adhoc = CouchbaseOrm::N1ql.config[:adhoc]
+                opts[:adhoc] = adhoc unless adhoc.nil?
                 Couchbase::Options::Query.new(**opts)
             end
 

--- a/spec/n1ql_spec.rb
+++ b/spec/n1ql_spec.rb
@@ -174,25 +174,25 @@ describe CouchbaseOrm::N1ql do
         N1QLTest.by_rating_reverse()
         expect(CouchbaseOrm.logger).to have_received(:debug).at_least(:once) do |&block|
             msg = block ? block.call : nil
-            msg == "N1QL query: select raw meta().id from `#{CouchbaseOrm::Connection.bucket.name}` where type=$1  order by name DESC  params: [\"n1_ql_test\"] return 0 rows with scan_consistency: #{described_class::DEFAULT_SCAN_CONSISTENCY}"
+            msg == "N1QL query: select raw meta().id from `#{CouchbaseOrm::Connection.bucket.name}` where type=$1  order by name DESC  params: [\"n1_ql_test\"] return 0 rows with scan_consistency: #{described_class::DEFAULT_SCAN_CONSISTENCY} adhoc: true"
         end
     end
 
     it "should log the set scan_consistency when n1ql query is executed with a specific scan_consistency" do
         allow(CouchbaseOrm.logger).to receive(:debug)
         default_n1ql_config = CouchbaseOrm::N1ql.config
-        CouchbaseOrm::N1ql.config({ scan_consistency: :not_bounded })
+        CouchbaseOrm::N1ql.config({ scan_consistency: :not_bounded, adhoc: true })
         N1QLTest.by_rating_reverse()
         expect(CouchbaseOrm.logger).to have_received(:debug).at_least(:once) do |&block|
             msg = block ? block.call : nil
-            msg == "N1QL query: select raw meta().id from `#{CouchbaseOrm::Connection.bucket.name}` where type=$1  order by name DESC  params: [\"n1_ql_test\"] return 0 rows with scan_consistency: not_bounded"
+            msg == "N1QL query: select raw meta().id from `#{CouchbaseOrm::Connection.bucket.name}` where type=$1  order by name DESC  params: [\"n1_ql_test\"] return 0 rows with scan_consistency: not_bounded adhoc: true"
         end
 
         CouchbaseOrm::N1ql.config(default_n1ql_config)
         N1QLTest.by_rating_reverse()
         expect(CouchbaseOrm.logger).to have_received(:debug).at_least(:once) do |&block|
             msg = block ? block.call : nil
-            msg == "N1QL query: select raw meta().id from `#{CouchbaseOrm::Connection.bucket.name}` where type=$1  order by name DESC  params: [\"n1_ql_test\"] return 0 rows with scan_consistency: #{described_class::DEFAULT_SCAN_CONSISTENCY}"
+            msg == "N1QL query: select raw meta().id from `#{CouchbaseOrm::Connection.bucket.name}` where type=$1  order by name DESC  params: [\"n1_ql_test\"] return 0 rows with scan_consistency: #{described_class::DEFAULT_SCAN_CONSISTENCY} adhoc: true"
         end
     end
 


### PR DESCRIPTION
## Summary

- Add `adhoc: true` to `N1ql.config` default, preserving current behavior (queries are not cached)
- Forward the `adhoc` option to `Couchbase::Options::Query` in both n1ql.rb (`run_query`) and relation.rb (`build_query_options`)
- Include `adhoc` value in debug log messages

**Depends on:** #34 (Parameterize N1QL queries)

## Context

With parameterized queries in place (PR #34), setting `adhoc: false` enables Couchbase to cache query plans for repeated queries. This PR exposes the option without changing the default behavior.

Users can opt-in to prepared-statement caching via:
```ruby
CouchbaseOrm::N1ql.config({ adhoc: false })
```

## Test plan

- [ ] Existing log specs updated to include `adhoc: true` in expected messages
- [ ] `/test --fail-fast=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)