### PR TITLE
feat: enable adhoc option for prepared statement plan caching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,9 +34,10 @@ jobs:
     name: ${{ matrix.ruby }} rails-${{ matrix.active-model }}  couchbase-${{ matrix.couchbase }}
     steps:
     - uses: actions/checkout@v3
-    - run: sudo apt-get update && sudo apt-get install libevent-dev libev-dev python3-httplib2
-    - run: wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb
-    - run: sudo apt install ./libtinfo5_6.3-2ubuntu0.1_amd64.deb
+    - run: |
+        sudo apt-get update
+        sudo apt-get install -y libevent-dev libev-dev python3-httplib2
+        sudo apt-get install -y libtinfo5 || sudo apt-get install -y libtinfo6
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}

--- a/docusaurus/docs/tutorial-ruby-couchbase-orm/07-sqlpp-queries.md
+++ b/docusaurus/docs/tutorial-ruby-couchbase-orm/07-sqlpp-queries.md
@@ -147,6 +147,47 @@ docs = N1QLTest.by_custom_rating_values(key: [[1, 2]]).collect { |ob| ob.name }
 
 In the above examples, the `collect` method is used to extract the `name` attribute from each document in the result set.
 
+## 7.8 Prepared Statement Plan Caching
+
+Couchbase Server can cache the query execution plan for a SQL++ query so that subsequent executions skip the planning step. CouchbaseOrm opts into this behaviour by default: every query is sent with `adhoc: false`, which tells the server to prepare and cache the plan on first execution and reuse it on subsequent ones.
+
+### Default behaviour
+
+No configuration is required. All queries — both `n1ql`-macro queries and relation queries (`where`, `all`, `first`, `last`, `ids`, `update_all`, `delete_all`) — use `adhoc: false` out of the box.
+
+### Disabling caching for a specific call
+
+Pass `adhoc: true` directly to the query method to execute without caching (useful for one-off or highly dynamic queries):
+
+```ruby
+# Run once without caching the plan
+N1QLTest.by_rating(key: 1, adhoc: true)
+
+# Relation query without caching
+User.where(country: 'FR').adhoc(true).to_a
+```
+
+### Disabling caching for a specific `n1ql` definition
+
+Set `adhoc: true` in the macro options to always run that particular query as ad-hoc:
+
+```ruby
+n1ql :by_dynamic_filter, emit_key: [:name], adhoc: true
+```
+
+### Changing the global default
+
+Override the thread-local config to change the default for all queries in the current thread:
+
+```ruby
+# Disable plan caching for all queries in this thread
+CouchbaseOrm::N1ql.config(adhoc: true)
+```
+
+### Override priority
+
+From highest to lowest: **per-call kwarg** > **per-`n1ql`-definition option** > **`N1ql.config`** > **default (`false`)**.
+
 ## 7.7 Indexing for SQL++
 
 To optimize the performance of SQL++ queries, it's important to create appropriate indexes on the fields used in the query conditions. Couchbase Server provides a way to create indexes using the Index service.

--- a/docusaurus/docs/tutorial-ruby-couchbase-orm/07-sqlpp-queries.md
+++ b/docusaurus/docs/tutorial-ruby-couchbase-orm/07-sqlpp-queries.md
@@ -149,30 +149,30 @@ In the above examples, the `collect` method is used to extract the `name` attrib
 
 ## 7.8 Prepared Statement Plan Caching
 
-Couchbase Server can cache the query execution plan for a SQL++ query so that subsequent executions skip the planning step. CouchbaseOrm opts into this behaviour by default: every query is sent with `adhoc: false`, which tells the server to prepare and cache the plan on first execution and reuse it on subsequent ones.
+Couchbase Server can cache the query execution plan for a SQL++ query so that subsequent executions skip the planning step. This is controlled by the `adhoc` query option: `adhoc: false` tells the server to prepare and cache the plan on first execution and reuse it on subsequent ones.
 
 ### Default behaviour
 
-No configuration is required. All queries — both `n1ql`-macro queries and relation queries (`where`, `all`, `first`, `last`, `ids`, `update_all`, `delete_all`) — use `adhoc: false` out of the box.
+By default CouchbaseOrm runs queries with `adhoc: true` (the Couchbase SDK default), meaning no plan caching. This preserves the existing behaviour — you opt into plan caching explicitly.
 
-### Disabling caching for a specific call
+### Enabling caching for a specific call
 
-Pass `adhoc: true` directly to the query method to execute without caching (useful for one-off or highly dynamic queries):
+Pass `adhoc: false` directly to the query method to prepare and cache the plan (useful for frequently repeated queries):
 
 ```ruby
-# Run once without caching the plan
-N1QLTest.by_rating(key: 1, adhoc: true)
+# Cache the plan for this query
+N1QLTest.by_rating(key: 1, adhoc: false)
 
-# Relation query without caching
-User.where(country: 'FR').adhoc(true).to_a
+# Relation query with plan caching
+User.where(country: 'FR').with(adhoc: false).to_a
 ```
 
-### Disabling caching for a specific `n1ql` definition
+### Enabling caching for a specific `n1ql` definition
 
-Set `adhoc: true` in the macro options to always run that particular query as ad-hoc:
+Set `adhoc: false` in the macro options to always cache the plan for that particular query:
 
 ```ruby
-n1ql :by_dynamic_filter, emit_key: [:name], adhoc: true
+n1ql :by_stable_filter, emit_key: [:name], adhoc: false
 ```
 
 ### Changing the global default
@@ -180,13 +180,13 @@ n1ql :by_dynamic_filter, emit_key: [:name], adhoc: true
 Override the thread-local config to change the default for all queries in the current thread:
 
 ```ruby
-# Disable plan caching for all queries in this thread
-CouchbaseOrm::N1ql.config(adhoc: true)
+# Enable plan caching for all queries in this thread
+CouchbaseOrm::N1ql.config(adhoc: false)
 ```
 
 ### Override priority
 
-From highest to lowest: **per-call kwarg** > **per-`n1ql`-definition option** > **`N1ql.config`** > **default (`false`)**.
+From highest to lowest: **per-call kwarg** > **per-`n1ql`-definition option** > **`N1ql.config`** > **default (`true`)**.
 
 ## 7.7 Indexing for SQL++
 

--- a/lib/couchbase-orm/n1ql.rb
+++ b/lib/couchbase-orm/n1ql.rb
@@ -23,7 +23,8 @@ module CouchbaseOrm
         def self.config(new_config = nil)
             Thread.current['__couchbaseorm_n1ql_config__'] = new_config if new_config
             Thread.current['__couchbaseorm_n1ql_config__'] || {
-                scan_consistency: DEFAULT_SCAN_CONSISTENCY
+                scan_consistency: DEFAULT_SCAN_CONSISTENCY,
+                adhoc: false
             }
         end
 
@@ -57,7 +58,10 @@ module CouchbaseOrm
                 @indexes[name] = method_opts
 
                 singleton_class.__send__(:define_method, name) do |key: NO_VALUE, **opts, &result_modifier|
-                    opts = options.merge(opts).reverse_merge(scan_consistency: CouchbaseOrm::N1ql.config[:scan_consistency])
+                    opts = options.merge(opts).reverse_merge(
+                        scan_consistency: CouchbaseOrm::N1ql.config[:scan_consistency],
+                        adhoc: CouchbaseOrm::N1ql.config[:adhoc]
+                    )
                     values = key == NO_VALUE ? NO_VALUE : convert_values(method_opts[:emit_key], key)
                     current_query = run_query(method_opts[:emit_key], values, query_fn, custom_order: custom_order, **opts.except(:include_docs, :key))
                     if result_modifier

--- a/lib/couchbase-orm/n1ql.rb
+++ b/lib/couchbase-orm/n1ql.rb
@@ -9,6 +9,7 @@ module CouchbaseOrm
         extend ActiveSupport::Concern
         NO_VALUE = :no_value_specified
         DEFAULT_SCAN_CONSISTENCY = :request_plus
+        DEFAULT_ADHOC = true
         # sanitize for injection query
         def self.sanitize(value)
             if value.is_a?(String)
@@ -22,10 +23,10 @@ module CouchbaseOrm
 
         def self.config(new_config = nil)
             Thread.current['__couchbaseorm_n1ql_config__'] = new_config if new_config
-            Thread.current['__couchbaseorm_n1ql_config__'] || {
+            {
                 scan_consistency: DEFAULT_SCAN_CONSISTENCY,
-                adhoc: false
-            }
+                adhoc: DEFAULT_ADHOC
+            }.merge(Thread.current['__couchbaseorm_n1ql_config__'] || {})
         end
 
         module ClassMethods

--- a/lib/couchbase-orm/relation.rb
+++ b/lib/couchbase-orm/relation.rb
@@ -238,7 +238,10 @@ module CouchbaseOrm
             end
 
             def build_query_options(positional_parameters: [])
-                opts = { scan_consistency: CouchbaseOrm::N1ql.config[:scan_consistency] }
+                opts = {
+                    scan_consistency: CouchbaseOrm::N1ql.config[:scan_consistency],
+                    adhoc: CouchbaseOrm::N1ql.config[:adhoc]
+                }
                 opts[:positional_parameters] = positional_parameters unless positional_parameters.empty?
                 Couchbase::Options::Query.new(**opts)
             end

--- a/lib/couchbase-orm/relation.rb
+++ b/lib/couchbase-orm/relation.rb
@@ -3,7 +3,7 @@ module CouchbaseOrm
         extend ActiveSupport::Concern
 
         class CouchbaseOrm_Relation
-            def initialize(model:, where: where = nil, order: order = nil, limit: limit = nil, _not: _not = false, strict_loading: strict_loading = false, adhoc: adhoc = nil)
+            def initialize(model:, where: where = nil, order: order = nil, limit: limit = nil, _not: _not = false, strict_loading: strict_loading = false, query_options: query_options = {})
                 CouchbaseOrm::logger.debug "CouchbaseOrm_Relation init: #{model} where:#{where.inspect} not:#{_not.inspect} order:#{order.inspect} limit: #{limit} strict_loading: #{strict_loading}"
                 @model = model
                 @limit = limit
@@ -12,7 +12,7 @@ module CouchbaseOrm
                 @order = merge_order(**order) if order
                 @where = merge_where(where, _not) if where
                 @strict_loading = strict_loading
-                @adhoc = adhoc
+                @query_options = query_options || {}
                 CouchbaseOrm::logger.debug "- #{to_s}"
             end
 
@@ -71,8 +71,12 @@ module CouchbaseOrm
                 !!@strict_loading
             end
 
+            def with(opts = {})
+                CouchbaseOrm_Relation.new(**initializer_arguments.merge(query_options: @query_options.merge(opts)))
+            end
+
             def adhoc(value)
-                CouchbaseOrm_Relation.new(**initializer_arguments.merge(adhoc: value))
+                with(adhoc: value)
             end
 
             def first
@@ -173,7 +177,7 @@ module CouchbaseOrm
             end
 
             def initializer_arguments
-                { model: @model, order: @order, where: @where, limit: @limit, strict_loading: @strict_loading, adhoc: @adhoc }
+                { model: @model, order: @order, where: @where, limit: @limit, strict_loading: @strict_loading, query_options: @query_options }
             end
 
             def merge_order(*lorder, **horder)
@@ -243,10 +247,7 @@ module CouchbaseOrm
             end
 
             def build_query_options(positional_parameters: [])
-                opts = {
-                    scan_consistency: CouchbaseOrm::N1ql.config[:scan_consistency],
-                    adhoc: @adhoc.nil? ? CouchbaseOrm::N1ql.config[:adhoc] : @adhoc
-                }
+                opts = CouchbaseOrm::N1ql.config.merge(@query_options)
                 opts[:positional_parameters] = positional_parameters unless positional_parameters.empty?
                 Couchbase::Options::Query.new(**opts)
             end
@@ -269,7 +270,7 @@ module CouchbaseOrm
 
             delegate :ids, :update_all, :delete_all, :count, :empty?, :filter, :reduce, :find_by, to: :all
 
-            delegate :where, :not, :order, :limit, :all, :strict_loading, :strict_loading?, :adhoc, to: :relation
+            delegate :where, :not, :order, :limit, :all, :strict_loading, :strict_loading?, :with, :adhoc, to: :relation
         end
     end
 end

--- a/lib/couchbase-orm/relation.rb
+++ b/lib/couchbase-orm/relation.rb
@@ -3,7 +3,7 @@ module CouchbaseOrm
         extend ActiveSupport::Concern
 
         class CouchbaseOrm_Relation
-            def initialize(model:, where: where = nil, order: order = nil, limit: limit = nil, _not: _not = false, strict_loading: strict_loading = false)
+            def initialize(model:, where: where = nil, order: order = nil, limit: limit = nil, _not: _not = false, strict_loading: strict_loading = false, adhoc: adhoc = nil)
                 CouchbaseOrm::logger.debug "CouchbaseOrm_Relation init: #{model} where:#{where.inspect} not:#{_not.inspect} order:#{order.inspect} limit: #{limit} strict_loading: #{strict_loading}"
                 @model = model
                 @limit = limit
@@ -12,6 +12,7 @@ module CouchbaseOrm
                 @order = merge_order(**order) if order
                 @where = merge_where(where, _not) if where
                 @strict_loading = strict_loading
+                @adhoc = adhoc
                 CouchbaseOrm::logger.debug "- #{to_s}"
             end
 
@@ -68,6 +69,10 @@ module CouchbaseOrm
 
             def strict_loading?
                 !!@strict_loading
+            end
+
+            def adhoc(value)
+                CouchbaseOrm_Relation.new(**initializer_arguments.merge(adhoc: value))
             end
 
             def first
@@ -168,7 +173,7 @@ module CouchbaseOrm
             end
 
             def initializer_arguments
-                { model: @model, order: @order, where: @where, limit: @limit, strict_loading: @strict_loading }
+                { model: @model, order: @order, where: @where, limit: @limit, strict_loading: @strict_loading, adhoc: @adhoc }
             end
 
             def merge_order(*lorder, **horder)
@@ -240,7 +245,7 @@ module CouchbaseOrm
             def build_query_options(positional_parameters: [])
                 opts = {
                     scan_consistency: CouchbaseOrm::N1ql.config[:scan_consistency],
-                    adhoc: CouchbaseOrm::N1ql.config[:adhoc]
+                    adhoc: @adhoc.nil? ? CouchbaseOrm::N1ql.config[:adhoc] : @adhoc
                 }
                 opts[:positional_parameters] = positional_parameters unless positional_parameters.empty?
                 Couchbase::Options::Query.new(**opts)
@@ -264,7 +269,7 @@ module CouchbaseOrm
 
             delegate :ids, :update_all, :delete_all, :count, :empty?, :filter, :reduce, :find_by, to: :all
 
-            delegate :where, :not, :order, :limit, :all, :strict_loading, :strict_loading?, to: :relation
+            delegate :where, :not, :order, :limit, :all, :strict_loading, :strict_loading?, :adhoc, to: :relation
         end
     end
 end

--- a/lib/couchbase-orm/relation.rb
+++ b/lib/couchbase-orm/relation.rb
@@ -75,10 +75,6 @@ module CouchbaseOrm
                 CouchbaseOrm_Relation.new(**initializer_arguments.merge(query_options: @query_options.merge(opts)))
             end
 
-            def adhoc(value)
-                with(adhoc: value)
-            end
-
             def first
                 n1ql_query, params = self.limit(1).to_n1ql_with_params
                 result = @model.cluster.query(n1ql_query, build_query_options(positional_parameters: params))
@@ -270,7 +266,7 @@ module CouchbaseOrm
 
             delegate :ids, :update_all, :delete_all, :count, :empty?, :filter, :reduce, :find_by, to: :all
 
-            delegate :where, :not, :order, :limit, :all, :strict_loading, :strict_loading?, :with, :adhoc, to: :relation
+            delegate :where, :not, :order, :limit, :all, :strict_loading, :strict_loading?, :with, to: :relation
         end
     end
 end

--- a/spec/n1ql_spec.rb
+++ b/spec/n1ql_spec.rb
@@ -196,20 +196,20 @@ describe CouchbaseOrm::N1ql do
         end
     end
 
-    it "should use adhoc: false by default for prepared statement plan caching" do
-        expect(Couchbase::Options::Query).to receive(:new).with(hash_including(adhoc: false)).and_call_original
+    it "should use adhoc: true by default (no prepared statement plan caching)" do
+        expect(Couchbase::Options::Query).to receive(:new).with(hash_including(adhoc: true)).and_call_original
         N1QLTest.by_rating_reverse()
     end
 
-    it "should allow overriding adhoc per call" do
-        expect(Couchbase::Options::Query).to receive(:new).with(hash_including(adhoc: true)).and_call_original
-        N1QLTest.by_rating_reverse(adhoc: true)
+    it "should allow overriding adhoc per call to enable plan caching" do
+        expect(Couchbase::Options::Query).to receive(:new).with(hash_including(adhoc: false)).and_call_original
+        N1QLTest.by_rating_reverse(adhoc: false)
     end
 
     it "should respect N1ql.config adhoc setting" do
         default_config = CouchbaseOrm::N1ql.config
-        CouchbaseOrm::N1ql.config({ adhoc: true })
-        expect(Couchbase::Options::Query).to receive(:new).with(hash_including(adhoc: true)).and_call_original
+        CouchbaseOrm::N1ql.config({ adhoc: false })
+        expect(Couchbase::Options::Query).to receive(:new).with(hash_including(adhoc: false)).and_call_original
         N1QLTest.by_rating_reverse()
     ensure
         CouchbaseOrm::N1ql.config(default_config)

--- a/spec/n1ql_spec.rb
+++ b/spec/n1ql_spec.rb
@@ -196,6 +196,25 @@ describe CouchbaseOrm::N1ql do
         end
     end
 
+    it "should use adhoc: false by default for prepared statement plan caching" do
+        expect(Couchbase::Options::Query).to receive(:new).with(hash_including(adhoc: false)).and_call_original
+        N1QLTest.by_rating_reverse()
+    end
+
+    it "should allow overriding adhoc per call" do
+        expect(Couchbase::Options::Query).to receive(:new).with(hash_including(adhoc: true)).and_call_original
+        N1QLTest.by_rating_reverse(adhoc: true)
+    end
+
+    it "should respect N1ql.config adhoc setting" do
+        default_config = CouchbaseOrm::N1ql.config
+        CouchbaseOrm::N1ql.config({ adhoc: true })
+        expect(Couchbase::Options::Query).to receive(:new).with(hash_including(adhoc: true)).and_call_original
+        N1QLTest.by_rating_reverse()
+    ensure
+        CouchbaseOrm::N1ql.config(default_config)
+    end
+
     after(:all) do
         N1QLTest.delete_all
     end

--- a/spec/relation_spec.rb
+++ b/spec/relation_spec.rb
@@ -506,5 +506,40 @@ describe CouchbaseOrm::Relation do
         expect(Couchbase::Options::Query).to receive(:new).with(hash_including(adhoc: false)).and_call_original
         RelationModel.where(active: true).ids
     end
+
+    describe "adhoc option" do
+        it "should return a relation when calling adhoc" do
+            expect(RelationModel.all.adhoc(true)).to be_a(CouchbaseOrm::Relation::CouchbaseOrm_Relation)
+        end
+
+        it "should pass adhoc: true to query options when set on the relation" do
+            expect(Couchbase::Options::Query).to receive(:new).with(hash_including(adhoc: true)).and_call_original
+            RelationModel.where(active: true).adhoc(true).ids
+        end
+
+        it "should pass adhoc: false to query options when explicitly set on the relation" do
+            CouchbaseOrm::N1ql.config(adhoc: true)
+            expect(Couchbase::Options::Query).to receive(:new).with(hash_including(adhoc: false)).and_call_original
+            RelationModel.where(active: true).adhoc(false).ids
+        ensure
+            CouchbaseOrm::N1ql.config(adhoc: false)
+        end
+
+        it "should override N1ql.config adhoc when set on the relation" do
+            CouchbaseOrm::N1ql.config(adhoc: true)
+            expect(Couchbase::Options::Query).to receive(:new).with(hash_including(adhoc: false)).and_call_original
+            RelationModel.where(active: true).adhoc(false).ids
+        ensure
+            CouchbaseOrm::N1ql.config(adhoc: false)
+        end
+
+        it "should be chainable with other relation methods" do
+            m1 = RelationModel.create!(active: true, age: 10)
+            _m2 = RelationModel.create!(active: false, age: 20)
+            expect(Couchbase::Options::Query).to receive(:new).with(hash_including(adhoc: true)).and_call_original
+            result = RelationModel.where(active: true).order(:age).adhoc(true).to_a
+            expect(result).to match_array([m1])
+        end
+    end
 end
 

--- a/spec/relation_spec.rb
+++ b/spec/relation_spec.rb
@@ -502,42 +502,35 @@ describe CouchbaseOrm::Relation do
         end
     end
 
-    it "should use adhoc: false by default for prepared statement plan caching" do
-        expect(Couchbase::Options::Query).to receive(:new).with(hash_including(adhoc: false)).and_call_original
+    it "should use adhoc: true by default (no prepared statement plan caching)" do
+        expect(Couchbase::Options::Query).to receive(:new).with(hash_including(adhoc: true)).and_call_original
         RelationModel.where(active: true).ids
     end
 
-    describe "adhoc option" do
-        it "should return a relation when calling adhoc" do
-            expect(RelationModel.all.adhoc(true)).to be_a(CouchbaseOrm::Relation::CouchbaseOrm_Relation)
+    describe "adhoc option via with" do
+        it "should return a relation when calling with(adhoc:)" do
+            expect(RelationModel.all.with(adhoc: false)).to be_a(CouchbaseOrm::Relation::CouchbaseOrm_Relation)
         end
 
-        it "should pass adhoc: true to query options when set on the relation" do
-            expect(Couchbase::Options::Query).to receive(:new).with(hash_including(adhoc: true)).and_call_original
-            RelationModel.where(active: true).adhoc(true).ids
-        end
-
-        it "should pass adhoc: false to query options when explicitly set on the relation" do
-            CouchbaseOrm::N1ql.config(adhoc: true)
+        it "should pass adhoc: false to query options when set on the relation" do
             expect(Couchbase::Options::Query).to receive(:new).with(hash_including(adhoc: false)).and_call_original
-            RelationModel.where(active: true).adhoc(false).ids
-        ensure
-            CouchbaseOrm::N1ql.config(adhoc: false)
+            RelationModel.where(active: true).with(adhoc: false).ids
         end
 
         it "should override N1ql.config adhoc when set on the relation" do
-            CouchbaseOrm::N1ql.config(adhoc: true)
-            expect(Couchbase::Options::Query).to receive(:new).with(hash_including(adhoc: false)).and_call_original
-            RelationModel.where(active: true).adhoc(false).ids
-        ensure
+            default_config = CouchbaseOrm::N1ql.config
             CouchbaseOrm::N1ql.config(adhoc: false)
+            expect(Couchbase::Options::Query).to receive(:new).with(hash_including(adhoc: true)).and_call_original
+            RelationModel.where(active: true).with(adhoc: true).ids
+        ensure
+            CouchbaseOrm::N1ql.config(default_config)
         end
 
         it "should be chainable with other relation methods" do
             m1 = RelationModel.create!(active: true, age: 10)
             _m2 = RelationModel.create!(active: false, age: 20)
-            expect(Couchbase::Options::Query).to receive(:new).with(hash_including(adhoc: true)).and_call_original
-            result = RelationModel.where(active: true).order(:age).adhoc(true).to_a
+            expect(Couchbase::Options::Query).to receive(:new).with(hash_including(adhoc: false)).and_call_original
+            result = RelationModel.where(active: true).order(:age).with(adhoc: false).to_a
             expect(result).to match_array([m1])
         end
     end

--- a/spec/relation_spec.rb
+++ b/spec/relation_spec.rb
@@ -501,5 +501,10 @@ describe CouchbaseOrm::Relation do
             end
         end
     end
+
+    it "should use adhoc: false by default for prepared statement plan caching" do
+        expect(Couchbase::Options::Query).to receive(:new).with(hash_including(adhoc: false)).and_call_original
+        RelationModel.where(active: true).ids
+    end
 end
 


### PR DESCRIPTION
## Summary

Expose the `adhoc` query option so callers can opt into Couchbase server-side prepared-statement plan caching (`adhoc: false`), while **preserving the existing default behaviour** (`adhoc: true`, no caching).

- Add `DEFAULT_ADHOC = true` and wire `adhoc` into `N1ql.config` so any customized config still falls back to the defaults (merge over `{ scan_consistency:, adhoc: }`)
- Thread `adhoc` through the `reverse_merge` in the n1ql-macro generated method (same pattern as `scan_consistency`)
- Read `adhoc` from `N1ql.config` in `Relation#build_query_options`, covering all relation paths (`where`, `all`, `first`, `last`, `ids`, `update_all`, `delete_all`)
- Per-query override on relations uses the generic `with(adhoc: false)` (no dedicated `adhoc` method)

Override priority (highest → lowest): per-call kwarg > per-`n1ql`-definition option > `N1ql.config` > default (`true`).

## Usage

```ruby
# Enable plan caching for a single macro query
N1QLTest.by_rating(key: 1, adhoc: false)

# Enable plan caching for a relation query
User.where(country: 'FR').with(adhoc: false).to_a

# Always cache the plan for a given n1ql definition
n1ql :by_stable_filter, emit_key: [:name], adhoc: false

# Change the thread-local default
CouchbaseOrm::N1ql.config(adhoc: false)
```

## Test plan

- [ ] 3 specs in `spec/n1ql_spec.rb`: default `adhoc: true`, per-call override to `false`, `N1ql.config` override
- [ ] Relation specs in `spec/relation_spec.rb`: default `adhoc: true`, `with(adhoc:)` override, config override, chainability
- [ ] Run full CI: `/test --fail-fast=false`

## CI fix

Replaced the brittle `wget` + `apt install ./libtinfo5_6.3-2ubuntu0.1_amd64.deb` steps with a single consolidated apt step that installs from the repository directly and falls back to `libtinfo6` on newer Ubuntu runner images (ubuntu-24.04). This eliminates CI failures caused by Ubuntu package pool URLs becoming stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)